### PR TITLE
Update assert-json-diff to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ log = "0.4"
 num = "0.3"
 
 [dev-dependencies]
-assert-json-diff = "1"
+assert-json-diff = "2"
 env_logger = "0.8"
 


### PR DESCRIPTION
Hey 👋 

I recently released assert-json-diff 2.0.0 which had [a few breaking changes](https://github.com/davidpdrsn/assert-json-diff/blob/main/CHANGELOG.md#200---2021-01-23).