### PR TITLE
contract_call -> simulate_transaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "0.14.8"
+version = "0.15.0"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"

--- a/src/amm.rs
+++ b/src/amm.rs
@@ -93,14 +93,12 @@ impl Web3 {
         ];
 
         debug!("tokens is  {:?}", tokens);
+        let payload = encode_call(
+            "quoteExactInputSingle(address,address,uint24,uint256,uint160)",
+            &tokens,
+        )?;
         let result = self
-            .contract_call(
-                quoter,
-                "quoteExactInputSingle(address,address,uint24,uint256,uint160)",
-                &tokens,
-                caller_address,
-                None,
-            )
+            .simulate_transaction(quoter, 0u8.into(), payload, caller_address, None)
             .await?;
         debug!("result is {:?}", result);
         Ok(Uint256::from_bytes_be(match result.get(0..32) {

--- a/src/erc20_utils.rs
+++ b/src/erc20_utils.rs
@@ -21,14 +21,12 @@ impl Web3 {
         own_address: Address,
         target_contract: Address,
     ) -> Result<bool, Web3Error> {
+        let payload = encode_call(
+            "allowance(address,address)",
+            &[own_address.into(), target_contract.into()],
+        )?;
         let allowance = self
-            .contract_call(
-                erc20,
-                "allowance(address,address)",
-                &[own_address.into(), target_contract.into()],
-                own_address,
-                None,
-            )
+            .simulate_transaction(erc20, 0u8.into(), payload, own_address, None)
             .await?;
 
         let allowance = Uint256::from_bytes_be(match allowance.get(0..32) {
@@ -158,14 +156,9 @@ impl Web3 {
         erc20: Address,
         target_address: Address,
     ) -> Result<Uint256, Web3Error> {
+        let payload = encode_call("balanceOf(address)", &[target_address.into()])?;
         let balance = self
-            .contract_call(
-                erc20,
-                "balanceOf(address)",
-                &[target_address.into()],
-                target_address,
-                None,
-            )
+            .simulate_transaction(erc20, 0u8.into(), payload, target_address, None)
             .await?;
 
         Ok(Uint256::from_bytes_be(match balance.get(0..32) {
@@ -183,8 +176,9 @@ impl Web3 {
         erc20: Address,
         caller_address: Address,
     ) -> Result<String, Web3Error> {
+        let payload = encode_call("name()", &[])?;
         let name = self
-            .contract_call(erc20, "name()", &[], caller_address, None)
+            .simulate_transaction(erc20, 0u8.into(), payload, caller_address, None)
             .await?;
 
         match String::from_utf8(name) {
@@ -200,8 +194,9 @@ impl Web3 {
         erc20: Address,
         caller_address: Address,
     ) -> Result<String, Web3Error> {
+        let payload = encode_call("symbol()", &[])?;
         let symbol = self
-            .contract_call(erc20, "symbol()", &[], caller_address, None)
+            .simulate_transaction(erc20, 0u8.into(), payload, caller_address, None)
             .await?;
 
         match String::from_utf8(symbol) {
@@ -217,8 +212,9 @@ impl Web3 {
         erc20: Address,
         caller_address: Address,
     ) -> Result<Uint256, Web3Error> {
+        let payload = encode_call("decimals()", &[])?;
         let decimals = self
-            .contract_call(erc20, "decimals()", &[], caller_address, None)
+            .simulate_transaction(erc20, 0u8.into(), payload, caller_address, None)
             .await?;
 
         Ok(Uint256::from_bytes_be(match decimals.get(0..32) {


### PR DESCRIPTION
This patch bumps Web30 for 0.15.0 and renames the contract_call function
to simulate_transaction. This better represents what the tx actually
does, and is paired with a much expanded doc comment detailing how the
function can be used and it's limiations.

The other major chang ehere is in how the TransactionRequest is
formatted, previously it was formatted very differently from the actual
transaction. Skipping the many from trait implementations handled in
Clarity for direct wrapping. I suspec this as contributing to encoding
flaws.