### PR TITLE
Added new GasLimitMultiplier enum of default value 1.2 to uniswap swa…

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -399,6 +399,7 @@ pub struct ConciseXdaiBlock {
 pub enum SendTxOption {
     GasPrice(Uint256),
     GasPriceMultiplier(f32),
+    GasLimitMultiplier(f32),
     GasLimit(Uint256),
     NetworkId(u64),
     Nonce(Uint256),


### PR DESCRIPTION
…p functions

In the time between our simulation and execution of the actual swap, many transactions occur, thereby changing
the value of the gas needed to perform this swap. Therefore, this padding ensures that we provide enough gas to prevent
a failing deposit transaction.