### PR TITLE
Use /proc/meminfo to size memory allocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "0.15.4"
+version = "0.16.2"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -44,7 +44,7 @@ impl Web3 {
 
     pub async fn eth_accounts(&self) -> Result<Vec<Address>, Web3Error> {
         self.jsonrpc_client
-            .request_method("eth_accounts", Vec::<String>::new(), self.timeout, None)
+            .request_method("eth_accounts", Vec::<String>::new(), self.timeout)
             .await
     }
 
@@ -52,7 +52,7 @@ impl Web3 {
     pub async fn eth_chainid(&self) -> Result<Option<Uint256>, Web3Error> {
         let ret: Result<Uint256, Web3Error> = self
             .jsonrpc_client
-            .request_method("eth_chainId", Vec::<String>::new(), self.timeout, None)
+            .request_method("eth_chainId", Vec::<String>::new(), self.timeout)
             .await;
 
         Ok(Some(ret?))
@@ -61,14 +61,14 @@ impl Web3 {
     pub async fn net_version(&self) -> Result<u64, Web3Error> {
         let ret: Result<String, Web3Error> = self
             .jsonrpc_client
-            .request_method("net_version", Vec::<String>::new(), self.timeout, None)
+            .request_method("net_version", Vec::<String>::new(), self.timeout)
             .await;
         Ok(ret?.parse()?)
     }
 
     pub async fn eth_new_filter(&self, new_filter: NewFilter) -> Result<Uint256, Web3Error> {
         self.jsonrpc_client
-            .request_method("eth_newFilter", vec![new_filter], self.timeout, None)
+            .request_method("eth_newFilter", vec![new_filter], self.timeout)
             .await
     }
 
@@ -78,7 +78,6 @@ impl Web3 {
                 "eth_getFilterChanges",
                 vec![format!("{:#x}", filter_id.clone())],
                 self.timeout,
-                Some(10_000_000),
             )
             .await
     }
@@ -89,19 +88,13 @@ impl Web3 {
                 "eth_uninstallFilter",
                 vec![format!("{:#x}", filter_id.clone())],
                 self.timeout,
-                None,
             )
             .await
     }
 
     pub async fn eth_get_logs(&self, new_filter: NewFilter) -> Result<Vec<Log>, Web3Error> {
         self.jsonrpc_client
-            .request_method(
-                "eth_getLogs",
-                vec![new_filter],
-                self.timeout,
-                Some(10_000_000),
-            )
+            .request_method("eth_getLogs", vec![new_filter], self.timeout)
             .await
     }
 
@@ -111,7 +104,6 @@ impl Web3 {
                 "eth_getTransactionCount",
                 vec![address.to_string(), "latest".to_string()],
                 self.timeout,
-                None,
             )
             .await
     }
@@ -122,7 +114,7 @@ impl Web3 {
     pub async fn eth_gas_price(&self) -> Result<Uint256, Web3Error> {
         let median_gas = self
             .jsonrpc_client
-            .request_method("eth_gasPrice", Vec::<String>::new(), self.timeout, None)
+            .request_method("eth_gasPrice", Vec::<String>::new(), self.timeout)
             .await?;
         let base_gas = self.get_base_fee_per_gas().await?;
         Ok(match base_gas {
@@ -136,7 +128,7 @@ impl Web3 {
         transaction: TransactionRequest,
     ) -> Result<Uint256, Web3Error> {
         self.jsonrpc_client
-            .request_method("eth_estimateGas", vec![transaction], self.timeout, None)
+            .request_method("eth_estimateGas", vec![transaction], self.timeout)
             .await
     }
 
@@ -146,7 +138,6 @@ impl Web3 {
                 "eth_getBalance",
                 vec![address.to_string(), "latest".to_string()],
                 self.timeout,
-                None,
             )
             .await
     }
@@ -156,13 +147,13 @@ impl Web3 {
         transactions: Vec<TransactionRequest>,
     ) -> Result<Uint256, Web3Error> {
         self.jsonrpc_client
-            .request_method("eth_sendTransaction", transactions, self.timeout, None)
+            .request_method("eth_sendTransaction", transactions, self.timeout)
             .await
     }
 
     pub async fn eth_call(&self, transaction: TransactionRequest) -> Result<Data, Web3Error> {
         self.jsonrpc_client
-            .request_method("eth_call", (transaction, "latest"), self.timeout, None)
+            .request_method("eth_call", (transaction, "latest"), self.timeout)
             .await
     }
 
@@ -172,13 +163,13 @@ impl Web3 {
         block: Uint256,
     ) -> Result<Data, Web3Error> {
         self.jsonrpc_client
-            .request_method("eth_call", (transaction, block), self.timeout, None)
+            .request_method("eth_call", (transaction, block), self.timeout)
             .await
     }
 
     pub async fn eth_block_number(&self) -> Result<Uint256, Web3Error> {
         self.jsonrpc_client
-            .request_method("eth_blockNumber", Vec::<String>::new(), self.timeout, None)
+            .request_method("eth_blockNumber", Vec::<String>::new(), self.timeout)
             .await
     }
 
@@ -188,7 +179,6 @@ impl Web3 {
                 "eth_getBlockByNumber",
                 (format!("{:#x}", block_number), true),
                 self.timeout,
-                Some(10_000_000),
             )
             .await
     }
@@ -202,7 +192,6 @@ impl Web3 {
                 "eth_getBlockByNumber",
                 (format!("{:#x}", block_number), true),
                 self.timeout,
-                Some(10_000_000),
             )
             .await
     }
@@ -216,7 +205,6 @@ impl Web3 {
                 "eth_getBlockByNumber",
                 (format!("{:#x}", block_number), false),
                 self.timeout,
-                None,
             )
             .await
     }
@@ -230,52 +218,31 @@ impl Web3 {
                 "eth_getBlockByNumber",
                 (format!("{:#x}", block_number), false),
                 self.timeout,
-                None,
             )
             .await
     }
 
     pub async fn eth_get_latest_block(&self) -> Result<ConciseBlock, Web3Error> {
         self.jsonrpc_client
-            .request_method(
-                "eth_getBlockByNumber",
-                ("latest", false),
-                self.timeout,
-                None,
-            )
+            .request_method("eth_getBlockByNumber", ("latest", false), self.timeout)
             .await
     }
 
     pub async fn xdai_get_latest_block(&self) -> Result<ConciseXdaiBlock, Web3Error> {
         self.jsonrpc_client
-            .request_method(
-                "eth_getBlockByNumber",
-                ("latest", false),
-                self.timeout,
-                None,
-            )
+            .request_method("eth_getBlockByNumber", ("latest", false), self.timeout)
             .await
     }
 
     pub async fn eth_get_latest_block_full(&self) -> Result<Block, Web3Error> {
         self.jsonrpc_client
-            .request_method(
-                "eth_getBlockByNumber",
-                ("latest", true),
-                self.timeout,
-                Some(10_000_000),
-            )
+            .request_method("eth_getBlockByNumber", ("latest", true), self.timeout)
             .await
     }
 
     pub async fn xdai_get_latest_block_full(&self) -> Result<XdaiBlock, Web3Error> {
         self.jsonrpc_client
-            .request_method(
-                "eth_getBlockByNumber",
-                ("latest", true),
-                self.timeout,
-                Some(10_000_000),
-            )
+            .request_method("eth_getBlockByNumber", ("latest", true), self.timeout)
             .await
     }
 
@@ -285,7 +252,6 @@ impl Web3 {
                 "eth_sendRawTransaction",
                 vec![format!("0x{}", bytes_to_hex_str(&data))],
                 self.timeout,
-                None,
             )
             .await
     }
@@ -301,14 +267,13 @@ impl Web3 {
                 // returning it we'll keep it consistent.
                 vec![format!("{:#066x}", hash)],
                 self.timeout,
-                None,
             )
             .await
     }
 
     pub async fn evm_snapshot(&self) -> Result<Uint256, Web3Error> {
         self.jsonrpc_client
-            .request_method("evm_snapshot", Vec::<String>::new(), self.timeout, None)
+            .request_method("evm_snapshot", Vec::<String>::new(), self.timeout)
             .await
     }
 
@@ -318,7 +283,6 @@ impl Web3 {
                 "evm_revert",
                 vec![format!("{:#066x}", snapshot_id)],
                 self.timeout,
-                None,
             )
             .await
     }
@@ -707,6 +671,10 @@ fn test_block_response() {
     let web3 = Web3::new("https://eth.altheamesh.com", Duration::from_secs(5));
     runner.block_on(async move {
         let val = web3.eth_get_latest_block().await;
+        let val = val.expect("Actix failure");
+        assert!(val.number > 10u32.into());
+
+        let val = web3.eth_get_latest_block_full().await;
         let val = val.expect("Actix failure");
         assert!(val.number > 10u32.into());
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod erc20_utils;
 pub mod eth_wrapping;
 mod event_utils;
 pub mod jsonrpc;
+mod mem;
 pub mod types;
 
 pub use event_utils::address_to_event;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,0 +1,131 @@
+//! This module contains an extremely simple memory usage parser for Linux based systems.
+//! Obviously this will not work on other platforms and we'll default to our normal buffer size.
+//! The intent is to protect low memory systems (usually embedded Linux) from crashes caused by
+//! OOM events. This may not work in containers or on specific cloud systems either.
+
+use std::cmp::min;
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+
+/// This struct represents memory info in a Linux
+/// system parsed from 'proc/meminfo'. All amounts
+/// are in kilobytes
+#[derive(Copy, Clone, PartialEq, Eq)]
+struct MemInfo {
+    /// total system memory
+    mem_total: usize,
+    /// memory not currently used by anything
+    mem_free: usize,
+    /// memory not used + memory used by disk cache
+    mem_available: usize,
+}
+
+fn get_memory_info() -> Option<MemInfo> {
+    let lines = get_lines("/proc/meminfo")?;
+    let mut lines = lines.iter();
+    let mem_total: usize = match lines.next() {
+        Some(line) => match line.split_whitespace().nth(1) {
+            Some(val) => {
+                let res = val.parse();
+                if res.is_err() {
+                    return None;
+                }
+                res.unwrap()
+            }
+            None => return None,
+        },
+        None => return None,
+    };
+    let mem_free: usize = match lines.next() {
+        Some(line) => match line.split_whitespace().nth(1) {
+            Some(val) => {
+                let res = val.parse();
+                if res.is_err() {
+                    return None;
+                }
+                res.unwrap()
+            }
+            None => return None,
+        },
+        None => return None,
+    };
+    let mem_available: usize = match lines.next() {
+        Some(line) => match line.split_whitespace().nth(1) {
+            Some(val) => {
+                let res = val.parse();
+                if res.is_err() {
+                    return None;
+                }
+                res.unwrap()
+            }
+            None => return None,
+        },
+        None => return None,
+    };
+
+    Some(MemInfo {
+        mem_available,
+        mem_free,
+        mem_total,
+    })
+}
+
+fn get_lines(filename: &str) -> Option<Vec<String>> {
+    let f = File::open(filename);
+
+    if f.is_err() {
+        return None;
+    }
+    let f = f.unwrap();
+
+    let file = BufReader::new(&f);
+    let mut out_lines = Vec::new();
+    for line in file.lines() {
+        match line {
+            Ok(val) => out_lines.push(val),
+            Err(_) => break,
+        }
+    }
+
+    Some(out_lines)
+}
+
+/// Gets the request buffer size which is either DEFAULT_BUFFER or the systems
+/// available memory if parsing /proc/meminfo succeeds, the DEFAULT_BUFFER size
+/// is larger than the total memory available on many users systems, this is ok
+/// must of the time because the memory is not actually allocated until it is used.
+///
+/// On the other hand it is possible for a payload that large to be sent, and the
+/// program or worse the system, will die due out of memory. This function resolves this
+/// issue for a subset of users running Linux by using the systems available memory, for
+/// those users an OOM crash will be impossible no matter the input size, although parsing
+/// will of course fail in that case.
+pub fn get_buffer_size() -> usize {
+    // default buffer size of 10GB in bytes, this is excessive by a good margin
+    // but memory is not actually allocated until it is used
+    const DEFAULT_BUFFER: usize = 10_000_000_000;
+    if let Some(mem_status) = get_memory_info() {
+        trace!("Successfully got memory info",);
+        // proc/meminfo has memory in kilobytes but the buffer uses bytes for it's memory
+        // size spec, we perform a conversion here. The only way this can ever fail is if
+        // we have a very strange system where memory addressing has several more bits than
+        // the system integer size and then that system is actually loaded with a huge amount
+        // of memory.
+        let mul_res = mem_status.mem_available.checked_mul(1000);
+        match mul_res {
+            Some(value) => {
+                // effectively just checking for zero, since this is probably
+                // a parsing error we're going to ignore it
+                let div_res = value.checked_div(2);
+                match div_res {
+                    Some(value) => min(DEFAULT_BUFFER, value),
+                    None => DEFAULT_BUFFER,
+                }
+            }
+            None => DEFAULT_BUFFER,
+        }
+    } else {
+        DEFAULT_BUFFER
+    }
+}


### PR DESCRIPTION
This patch removes the ability for the user to hint at the desired
response size on ETH calls. This value was not all that useful and
created problems around incorrect hints.

What this patch does is set a default buffer size to an enormous 10GB,
this will not OOM users in the common case because memory is only
allocated as actually needed, a few tens of megabytes at most.

The primary concern to be resolved in this patch was dealing with
OpenWRT routers and other low memory systems where it's very feasible to
have a 50MB response OOM the device on deserialization. So we import a
very simple 'proc/meminfo' parser from althea_rs that lets us set the
maximum parsing size to a fraction of the system available memory and
ensure that we can both parse the largest responses possible and we
incur no crash or OOM risk.

Due to the way this is implemented it extends to almost all Linux
systems and provides protection for potential 500MB or 1GB response
sizes on say small cloud systems as well.