### PR TITLE
Check approved in swap_uniswap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "0.16.2"
+version = "0.16.3"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"

--- a/src/amm.rs
+++ b/src/amm.rs
@@ -224,10 +224,23 @@ impl Web3 {
             options.push(SendTxOption::GasLimitMultiplier(glm));
         }
 
-        let _token_in_approval = self
-            .approve_erc20_transfers(token_in, eth_private_key, router, None, vec![])
-            .await
-            .unwrap();
+        let approved = self
+            .check_erc20_approved(token_in, eth_address, router)
+            .await?;
+        if !approved {
+            let nonce = self.eth_get_transaction_count(eth_address).await?;
+            let _token_in_approval = self
+                .approve_erc20_transfers(
+                    token_in,
+                    eth_private_key,
+                    router,
+                    None,
+                    vec![SendTxOption::Nonce(nonce.clone())],
+                )
+                .await
+                .unwrap();
+            options.push(SendTxOption::Nonce(nonce + 1u8.into()));
+        }
         debug!("token_in approved");
 
         debug!("payload is  {:?}", payload);


### PR DESCRIPTION
Previously this function would always send an approval tx without
checking if it was really needed or not. Furthermore when sending that
appoval tx it would not wait for the response, meaning that the
following transaction would share the same txid and barring some race
conditions the trade would execute and fail without the approval or the
approval would execute and the trade never run.

This patch resolves these issues by manually specifying the nonce,
allowing both transactions to enter the mempool and run sequentially, we
also check if approval is actually required.