### PR TITLE
Add wait_timeout to wrapping and amm functions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,37 +1,46 @@
 name: Rust
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
+        continue-on-error: true
+      - name: Build
+        run: cargo build --verbose
   runs_test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
+        continue-on-error: true
+      - name: Run tests
+        run: cargo test --verbose
   code_formatting:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Check code formatting
-      run: rustup component add rustfmt && cargo fmt --all -- --check
+      - uses: actions/checkout@v2
+      - name: Check code formatting
+        run: rustup component add rustfmt && cargo fmt --all -- --check
   clippy_lint:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Check for Clippy lints
-      run: rustup component add clippy && cargo clippy --all --all-targets --all-features -- -D warnings
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
+        continue-on-error: true
+      - name: Check for Clippy lints
+        run: rustup component add clippy && cargo clippy --all --all-targets --all-features -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "0.16.3"
+version = "0.17.0"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"

--- a/src/erc20_utils.rs
+++ b/src/erc20_utils.rs
@@ -79,14 +79,11 @@ impl Web3 {
 
         // wait for transaction to enter the chain if the user has requested it
         if let Some(timeout) = timeout {
-            self.wait_for_event_alt(
+            future_timeout(
                 timeout,
-                vec![erc20],
-                "Approval(address,address,uint256)",
-                vec![vec![own_address.into()], vec![target_contract.into()]],
-                |_| true,
+                self.wait_for_transaction(txid.clone(), timeout, None),
             )
-            .await?;
+            .await??;
         }
 
         Ok(txid)

--- a/src/eth_wrapping.rs
+++ b/src/eth_wrapping.rs
@@ -1,9 +1,10 @@
+use crate::amm::WETH_CONTRACT_ADDRESS;
+use crate::{client::Web3, jsonrpc::error::Web3Error};
 use clarity::abi::Token;
 use clarity::Address;
 use clarity::{abi::encode_call, PrivateKey, Uint256};
-
-use crate::amm::WETH_CONTRACT_ADDRESS;
-use crate::{client::Web3, jsonrpc::error::Web3Error};
+use std::time::Duration;
+use tokio::time::timeout as future_timeout;
 
 // Performs wrapping and unwrapping of eth, along with balance checking
 impl Web3 {
@@ -12,14 +13,25 @@ impl Web3 {
         amount: Uint256,
         secret: PrivateKey,
         weth_address: Option<Address>,
+        wait_timeout: Option<Duration>,
     ) -> Result<Uint256, Web3Error> {
         let own_address = secret.to_public_key().unwrap();
         let sig = "deposit()";
         let tokens = [];
         let payload = encode_call(sig, &tokens).unwrap();
         let weth_address = weth_address.unwrap_or(*WETH_CONTRACT_ADDRESS);
-        self.send_transaction(weth_address, payload, amount, own_address, secret, vec![])
-            .await
+        let txid = self
+            .send_transaction(weth_address, payload, amount, own_address, secret, vec![])
+            .await?;
+
+        if let Some(timeout) = wait_timeout {
+            future_timeout(
+                timeout,
+                self.wait_for_transaction(txid.clone(), timeout, None),
+            )
+            .await??;
+        }
+        Ok(txid)
     }
 
     pub async fn unwrap_eth(
@@ -27,20 +39,31 @@ impl Web3 {
         amount: Uint256,
         secret: PrivateKey,
         weth_address: Option<Address>,
+        wait_timeout: Option<Duration>,
     ) -> Result<Uint256, Web3Error> {
         let own_address = secret.to_public_key().unwrap();
         let sig = "withdraw(uint256)";
         let tokens = [Token::Uint(amount)];
         let payload = encode_call(sig, &tokens).unwrap();
         let weth_address = weth_address.unwrap_or(*WETH_CONTRACT_ADDRESS);
-        self.send_transaction(
-            weth_address,
-            payload,
-            0u16.into(),
-            own_address,
-            secret,
-            vec![],
-        )
-        .await
+        let txid = self
+            .send_transaction(
+                weth_address,
+                payload,
+                0u16.into(),
+                own_address,
+                secret,
+                vec![],
+            )
+            .await?;
+
+        if let Some(timeout) = wait_timeout {
+            future_timeout(
+                timeout,
+                self.wait_for_transaction(txid.clone(), timeout, None),
+            )
+            .await??;
+        }
+        Ok(txid)
     }
 }


### PR DESCRIPTION
Prevously the functions for wrapping ETH and making AMM calls did not
have the standard wait_timeout parameter used for functions that make
transactions.

This was not revealed in testing becuase the use of HardHat on automine
caused transactions to be instantly included, bypassing the the
real-world issue of race conditions caused by the block queue process.

When a tx is submitted it takes some time to confirm, during that time
if you send another tx it's nonce will be in conflict with the first tx,
since eth_get_transaction_count() does not include pending transactions.

What this does in effect is create a pileup of race conditions in the
code anywhere transactions are sent but not waited for.