### PR TITLE
Make `mix_hash` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "web30"
 version = "0.17.1"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
+repository = "https://github.com/althea-net/web30"
 license = "Apache-2.0"
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,3 @@ num = "0.4"
 [dev-dependencies]
 actix = "0.12"
 env_logger = "0.9"
-

--- a/src/types.rs
+++ b/src/types.rs
@@ -159,7 +159,7 @@ pub struct NewFilter {
     pub topics: Option<Vec<Option<Vec<Option<String>>>>>,
 }
 
-#[derive(Serialize, Clone, Eq, PartialEq)]
+#[derive(Serialize, Clone, Eq, PartialEq, Debug)]
 pub struct TransactionRequest {
     //The address the transaction is send from.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -325,7 +325,7 @@ pub struct ConciseBlock {
     pub logs_bloom: Data,
     pub miner: Address,
     #[serde(rename = "mixHash")]
-    pub mix_hash: Uint256,
+    pub mix_hash: Option<Uint256>,
     pub nonce: Uint256,
     pub number: Uint256,
     #[serde(rename = "parentHash")]


### PR DESCRIPTION
When adapting web30 for use with Near/Aurora, I found that their json-rpc responses omitted a `mix_hash` field when `eth_getBlockByNumber` is called. It took me forever to find the root cause, because the `#[serde(flatten)]` on `pub data: ResponseData` in the `Response` struct causes serde to use a very generic `"Size Limit 3206760000 Web3 Error Json deserialize error: data did not match any variant of untagged enum ResponseData at line 1 column 1317"` whenever a deserialization error happens with the `ResponseData` struct. I have kept a comment block of debugging code that I will probably use again as we bridge to more chains with subtle differences between them. I uncommented the `Debug` bound since `request_method` is private anyway.

`web30` does not use the `mix_hash` field, but downstream crates might, so a version bump is needed.

I also added a repository link in Cargo.toml, so that I have a quick link when going through crates.io.