### PR TITLE
Added an enum to deserialize syncing status of a node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"

--- a/src/types.rs
+++ b/src/types.rs
@@ -416,6 +416,21 @@ where
     }
 }
 
+/// This enum encapsulates the syncing status returned by a call to eth_syncing
+/// This will either return a bool 'false' if not syncing, or an object with details
+/// about which blocks are syncing
+#[derive(Serialize, Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum SyncingStatus {
+    NotSyncing(bool),
+    #[serde(rename_all = "camelCase")]
+    Syncing {
+        starting_block: Uint256,
+        current_block: Uint256,
+        highest_block: Uint256,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Previously, eth_syncing would return a json deserialization error when querying a syncing node,
Adding an enum here fixes this issue