### PR TITLE
Gas estimator improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "0.18.9"
+version = "0.18.10"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"

--- a/src/amm.rs
+++ b/src/amm.rs
@@ -655,7 +655,7 @@ fn swap_hardhat_eth_in_test() {
     use actix::System;
     use env_logger::{Builder, Env};
     use std::time::Duration;
-    Builder::from_env(Env::default().default_filter_or("warn")).init(); // Change to debug for logs
+    Builder::from_env(Env::default().default_filter_or("warn")).init(); // Change to warn for logs
     let runner = System::new();
 
     let web3 = Web3::new("http://localhost:8545", Duration::from_secs(300));


### PR DESCRIPTION
Fix Ord implementation, a mix up resulted in Descending rather than Ascending sorts in get_acceptable_gas_price()
Add history expansion, allowing multithreaded use with lazy_static
Add latest_gas_price() to return the latest stored gas price sample