### PR TITLE
Add erc20 balance fetching for contracts with 0 ETH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -218,7 +218,11 @@ impl Web3 {
         let latest_known_block = self.eth_synced_block_number().await?;
         if block <= latest_known_block {
             self.jsonrpc_client
-                .request_method("eth_call", (transaction, block), self.timeout)
+                .request_method(
+                    "eth_call",
+                    (transaction, format!("{:#x}", block.0)), // THIS IS THE MAGIC I NEEDED
+                    self.timeout,
+                )
                 .await
         } else if self.eth_syncing().await? {
             Err(Web3Error::SyncingNode(


### PR DESCRIPTION
When fetching erc20 balances, the `target_address` was used as the gas payer, but that meant querying the Gravity.sol balance resulted in an InsufficientGas error.

get_erc20_balance_as_address and get_erc20_balance_at_height_as_address have been added to address this issue.

This is a non-breaking API change, functionality of the existing API has not changed.