### PR TITLE
Typed transaction support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ num-traits = "0.2"
 actix = "0.13"
 env_logger = "0.10"
 
+[patch.crates-io]
+clarity = {git = "https://github.com/althea-net/clarity.git", ref = "112453b9c94d07246d48412b10d668cc4843b252"}

--- a/src/amm.rs
+++ b/src/amm.rs
@@ -602,7 +602,6 @@ impl Web3 {
                 router,
                 payload,
                 0u32.into(),
-                eth_address,
                 eth_private_key,
                 options,
             )
@@ -829,7 +828,6 @@ impl Web3 {
                 router,
                 payload,
                 amount,
-                eth_address,
                 eth_private_key,
                 options,
             )

--- a/src/erc20_utils.rs
+++ b/src/erc20_utils.rs
@@ -60,7 +60,6 @@ impl Web3 {
         timeout: Option<Duration>,
         options: Vec<SendTxOption>,
     ) -> Result<Uint256, Web3Error> {
-        let own_address = eth_private_key.to_address();
         let payload = encode_call(
             "approve(address,uint256)",
             &[target_contract.into(), Uint256::max_value().into()],
@@ -71,7 +70,6 @@ impl Web3 {
                 erc20,
                 payload,
                 0u32.into(),
-                own_address,
                 eth_private_key,
                 options,
             )
@@ -103,8 +101,6 @@ impl Web3 {
         wait_timeout: Option<Duration>,
         options: Vec<SendTxOption>,
     ) -> Result<Uint256, Web3Error> {
-        let sender_address = sender_private_key.to_address();
-
         // if the user sets a gas limit we should honor it, if they don't we
         // should add the default
         let mut has_gas_limit = false;
@@ -127,7 +123,6 @@ impl Web3 {
                     &[recipient.into(), amount.into()],
                 )?,
                 0u32.into(),
-                sender_address,
                 sender_private_key,
                 options,
             )

--- a/src/erc721_utils.rs
+++ b/src/erc721_utils.rs
@@ -64,7 +64,6 @@ impl Web3 {
         timeout: Option<Duration>,
         options: Vec<SendTxOption>,
     ) -> Result<Uint256, Web3Error> {
-        let own_address = eth_private_key.to_address();
         // function approve(address _approved, uint256 _tokenId)
         let payload = encode_call(
             "approve(address,uint256)",
@@ -76,7 +75,6 @@ impl Web3 {
                 erc721,
                 payload,
                 0u32.into(),
-                own_address,
                 eth_private_key,
                 options,
             )
@@ -134,7 +132,6 @@ impl Web3 {
                     ],
                 )?,
                 0u32.into(),
-                sender_address,
                 sender_private_key,
                 options,
             )

--- a/src/eth_wrapping.rs
+++ b/src/eth_wrapping.rs
@@ -15,13 +15,12 @@ impl Web3 {
         weth_address: Option<Address>,
         wait_timeout: Option<Duration>,
     ) -> Result<Uint256, Web3Error> {
-        let own_address = secret.to_address();
         let sig = "deposit()";
         let tokens = [];
         let payload = encode_call(sig, &tokens).unwrap();
         let weth_address = weth_address.unwrap_or(*WETH_CONTRACT_ADDRESS);
         let txid = self
-            .send_transaction(weth_address, payload, amount, own_address, secret, vec![])
+            .send_transaction(weth_address, payload, amount, secret, vec![])
             .await?;
 
         if let Some(timeout) = wait_timeout {
@@ -37,7 +36,6 @@ impl Web3 {
         weth_address: Option<Address>,
         wait_timeout: Option<Duration>,
     ) -> Result<Uint256, Web3Error> {
-        let own_address = secret.to_address();
         let sig = "withdraw(uint256)";
         let tokens = [Token::Uint(amount)];
         let payload = encode_call(sig, &tokens).unwrap();
@@ -47,7 +45,6 @@ impl Web3 {
                 weth_address,
                 payload,
                 0u16.into(),
-                own_address,
                 secret,
                 vec![],
             )

--- a/src/jsonrpc/error.rs
+++ b/src/jsonrpc/error.rs
@@ -33,6 +33,7 @@ pub enum Web3Error {
         time: Duration,
     },
     SyncingNode(String),
+    PreLondon
 }
 
 impl From<ParseIntError> for Web3Error {
@@ -93,6 +94,9 @@ impl Display for Web3Error {
             ),
             Web3Error::SyncingNode(val) => {
                 write!(f, "Web3 Node is syncing {val}")
+            }
+            Web3Error::PreLondon => {
+                write!(f, "Web3, this function sends EIP1559 tx but the connected chain does not support them!")
             }
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -295,12 +295,12 @@ pub struct ConciseBlock {
 /// Used to configure send_transaction
 #[derive(Debug, Clone, PartialEq)]
 pub enum SendTxOption {
-    GasPrice(Uint256),
-    GasPriceMultiplier(f32),
+    GasMaxFee(Uint256),
+    GasPriorityFee(Uint256),
     GasLimitMultiplier(f32),
     GasLimit(Uint256),
-    NetworkId(u64),
     Nonce(Uint256),
+    AccessList(Vec<(Address, Vec<Uint256>)>)
 }
 
 fn parse_possibly_empty_hex_val<'de, D>(deserializer: D) -> Result<Uint256, D::Error>


### PR DESCRIPTION
This updates Web30 to support typed transactions from Clarity and implement eip1559 tx by default.

Note: this needs a send legacy tx function for Althea usage due to backwards compatbility needs.